### PR TITLE
fix: local date time format json to iso

### DIFF
--- a/src/main/java/org/ktb/modie/config/AppConfig.java
+++ b/src/main/java/org/ktb/modie/config/AppConfig.java
@@ -25,6 +25,7 @@ public class AppConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());  // JavaTimeModule 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.findAndRegisterModules();  // 필요한 모든 모듈을 자동 등록
         return objectMapper;
     }

--- a/src/main/java/org/ktb/modie/config/AppConfig.java
+++ b/src/main/java/org/ktb/modie/config/AppConfig.java
@@ -1,5 +1,6 @@
 package org.ktb.modie.config;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -24,6 +25,7 @@ public class AppConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());  // JavaTimeModule 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.findAndRegisterModules();  // 필요한 모든 모듈을 자동 등록
         return objectMapper;
     }

--- a/src/main/java/org/ktb/modie/config/AppConfig.java
+++ b/src/main/java/org/ktb/modie/config/AppConfig.java
@@ -25,7 +25,6 @@ public class AppConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());  // JavaTimeModule 등록
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.findAndRegisterModules();  // 필요한 모든 모듈을 자동 등록
         return objectMapper;
     }

--- a/src/main/java/org/ktb/modie/presentation/v1/dto/MeetDto.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/dto/MeetDto.java
@@ -1,5 +1,6 @@
 package org.ktb.modie.presentation.v1.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -40,7 +41,6 @@ public record MeetDto(
 
     @Schema(description = "모임 시작 시간 (ISO 형식)", example = "2025-02-20T18:00:00")
     @NotNull
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     LocalDateTime meetAt,
 
     @Schema(description = "총 발생 비용 (0~10,000,000)", example = "10000")
@@ -55,7 +55,7 @@ public record MeetDto(
 
     @Schema(description = "생성시각", example = "2025-03-18T18:00:00")
     @NotNull
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime createdAt,
 
     @Schema(description = "유저의 상태", example = "owner")

--- a/src/main/java/org/ktb/modie/presentation/v1/dto/MeetDto.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/dto/MeetDto.java
@@ -41,6 +41,7 @@ public record MeetDto(
 
     @Schema(description = "모임 시작 시간 (ISO 형식)", example = "2025-02-20T18:00:00")
     @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime meetAt,
 
     @Schema(description = "총 발생 비용 (0~10,000,000)", example = "10000")

--- a/src/main/java/org/ktb/modie/presentation/v1/dto/MeetSummaryDto.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/dto/MeetSummaryDto.java
@@ -2,6 +2,7 @@ package org.ktb.modie.presentation.v1.dto;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetSummaryDto(
@@ -15,6 +16,7 @@ public record MeetSummaryDto(
     String type,
 
     @Schema(description = "모임 시작 시간", example = "2025-03-20T10:00:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime meetAt,
 
     @Schema(description = "주소", example = "제주특별자치도 제주시 월성로 4길 19")


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
단순 스키마 문제 인줄 알았지만
브랜치 병합 중 생긴 date time format 에러 
### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Resolves #[50]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. MeetDto 및 MeetSummaryDto LocalDateTime 타입에
`  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")` 처리


### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. [테스트 1]
2. [테스트 2]
3. [테스트 3]

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
처음에는 Dto 어노테이션 문제로 인지 
-> 채팅 브랜치 병합되면서 발생한 문제 

objectMapper에서 설정 변경하면 채팅에 문제가 없는지 

-> meet LocalDateTime 관련 Dto에 
`  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")`
처리해서 문제해결 


