### PR TITLE
Fix - 모임 나가기 관련 예외처리

### DIFF
--- a/src/main/java/org/ktb/modie/repository/UserMeetRepository.java
+++ b/src/main/java/org/ktb/modie/repository/UserMeetRepository.java
@@ -14,7 +14,9 @@ import org.springframework.data.repository.query.Param;
 public interface UserMeetRepository extends JpaRepository<UserMeet, Long> {
     Optional<UserMeet> findUserMeetByUser_UserIdAndMeet_MeetIdAndDeletedAtIsNull(String userId, Long meetId);
 
-    int countByMeet(Meet meet);
+    Optional<UserMeet> findUserMeetByUser_UserIdAndMeet_MeetId(String userId, Long meetId);
+
+    int countByMeetAndDeletedAtIsNull(Meet meet);
 
     @Query("SELECT COUNT(um) FROM UserMeet um WHERE um.meet.meetId = :meetId AND um.isPayed = false")
     Long countUnpaidUsersByMeetId(@Param("meetId") Long meetId);

--- a/src/main/java/org/ktb/modie/repository/UserMeetRepository.java
+++ b/src/main/java/org/ktb/modie/repository/UserMeetRepository.java
@@ -1,5 +1,8 @@
 package org.ktb.modie.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.ktb.modie.domain.Meet;
 import org.ktb.modie.domain.UserMeet;
 import org.ktb.modie.presentation.v1.dto.UserDto;
@@ -7,12 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
-
 // userMeet
 public interface UserMeetRepository extends JpaRepository<UserMeet, Long> {
-    Optional<UserMeet> findUserMeetByUser_UserIdAndMeet_MeetId(String userId, Long meetId);
+    Optional<UserMeet> findUserMeetByUser_UserIdAndMeet_MeetIdAndDeletedAtIsNull(String userId, Long meetId);
 
     int countByMeet(Meet meet);
 

--- a/src/main/java/org/ktb/modie/service/MeetService.java
+++ b/src/main/java/org/ktb/modie/service/MeetService.java
@@ -80,7 +80,7 @@ public class MeetService {
         }
 
         // 중복 참여 방지
-        if (userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetId(userId, meetId).isPresent()) {
+        if (userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetIdAndDeletedAtIsNull(userId, meetId).isPresent()) {
             throw new BusinessException(CustomErrorCode.ALREADY_JOINED_MEET);
         }
 
@@ -209,7 +209,7 @@ public class MeetService {
         }
 
         // 사용자가 해당 모임에 참여 중인지 확인
-        UserMeet userMeet = userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetId(userId, meetId)
+        UserMeet userMeet = userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetIdAndDeletedAtIsNull(userId, meetId)
             .orElseThrow(() -> new BusinessException(CustomErrorCode.PERMISSION_DENIED_NOT_MEMBER));
 
         if (userMeet.getDeletedAt() != null) {
@@ -293,7 +293,8 @@ public class MeetService {
         }
 
         // 해당 유저가 해당 모임에 참여 중인지 확인
-        UserMeet userMeet = userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetId(request.userId(), meetId)
+        UserMeet userMeet = userMeetRepository.findUserMeetByUser_UserIdAndMeet_MeetIdAndDeletedAtIsNull(
+                request.userId(), meetId)
             .orElseThrow(() -> new BusinessException(CustomErrorCode.SETTLEMENT_PERMISSION_DENIED_NOT_MEMBER));
 
         // 정산 상태 변경 (true <-> false 토글)


### PR DESCRIPTION
### Description
모임 나가기 관련 예외 사항 처리

### Related Issues
- close #87 

### Changes Made
1. 나간 모임을 재참여할 때 이미 참여한 사용자라고 뜨는 예외처리
    - userMeetRepository에 메소드 추가
2. 모임을 나갔을 때 getMeetList에서 memberCount가 수정되지 않는 예외처리
    - userMeetRepository에 countByMeet -> countByMeetAndDeletedAtIsNull 메소드 수정
3.  나간 사용자가 재참여할 때 userMeet 데이터가 새로 생기는 예외처리
    - meetService 로직 수정

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.