### PR TITLE
Feat - 모임 목록 조회 정렬(모임 시각 기준 DESC)

### DIFF
--- a/src/main/java/org/ktb/modie/repository/MeetRepository.java
+++ b/src/main/java/org/ktb/modie/repository/MeetRepository.java
@@ -22,6 +22,7 @@ public interface MeetRepository extends JpaRepository<Meet, Long> {
         OR m.meetType = :meetType)
         AND ((:isCompleted = false AND m.completedAt IS NULL) OR (:isCompleted = true AND m.completedAt IS NOT NULL))
         AND m.deletedAt IS NULL
+        ORDER BY m.meetAt DESC
         """)
     Page<Meet> findFilteredMeets(
         @Param("userId") String userId,


### PR DESCRIPTION
### Description
모임 목록 조회 시 `meetAt` 기준으로 내림차순 정렬되도록 쿼리를 수정했습니다.  
최신 일정의 모임이 상단에 노출되도록 개선했습니다.

### Related Issues
- Resolves #103

### Changes Made
1. `meetAt` 필드를 기준으로 DESC 정렬 로직 추가

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
