### PR TITLE
API - 모임 정산 정보 제공

### DIFF
--- a/src/main/java/org/ktb/modie/presentation/v1/controller/MeetApi.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/controller/MeetApi.java
@@ -3,6 +3,7 @@ package org.ktb.modie.presentation.v1.controller;
 import org.ktb.modie.core.response.SuccessResponse;
 import org.ktb.modie.presentation.v1.dto.CreateMeetRequest;
 import org.ktb.modie.presentation.v1.dto.CreateMeetResponse;
+import org.ktb.modie.presentation.v1.dto.GetMeetPaymentResponse;
 import org.ktb.modie.presentation.v1.dto.MeetDto;
 import org.ktb.modie.presentation.v1.dto.MeetListResponse;
 import org.ktb.modie.presentation.v1.dto.UpdateMeetRequest;
@@ -148,5 +149,12 @@ public interface MeetApi {
         @RequestAttribute("userId") String userId,
         @PathVariable("meetId") Long meetId,
         @RequestBody @Min(0) @Max(10000000) int totalCost
+    );
+
+    @Operation(summary = "정산 정보 조회", description = "모임 정산 정보 조회")
+    @GetMapping("/{meetId}/payments")
+    ResponseEntity<SuccessResponse<GetMeetPaymentResponse>> getMeetPayment(
+        @RequestAttribute("userId") String userId,
+        @PathVariable("meetId") Long meetId
     );
 }

--- a/src/main/java/org/ktb/modie/presentation/v1/controller/MeetController.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/controller/MeetController.java
@@ -3,6 +3,7 @@ package org.ktb.modie.presentation.v1.controller;
 import org.ktb.modie.core.response.SuccessResponse;
 import org.ktb.modie.presentation.v1.dto.CreateMeetRequest;
 import org.ktb.modie.presentation.v1.dto.CreateMeetResponse;
+import org.ktb.modie.presentation.v1.dto.GetMeetPaymentResponse;
 import org.ktb.modie.presentation.v1.dto.MeetDto;
 import org.ktb.modie.presentation.v1.dto.MeetListResponse;
 import org.ktb.modie.presentation.v1.dto.UpdateMeetRequest;
@@ -88,6 +89,11 @@ public class MeetController implements MeetApi {
         meetService.updateTotalCost(userId, meetId, totalCost);
 
         return SuccessResponse.ofNoData().asHttp(HttpStatus.OK);
+    }
+
+    public ResponseEntity<SuccessResponse<GetMeetPaymentResponse>> getMeetPayment(String userId, Long meetId) {
+        GetMeetPaymentResponse response = meetService.getMeetPaymentInfo(userId, meetId);
+        return SuccessResponse.of(response).asHttp(HttpStatus.OK);
     }
 
 }

--- a/src/main/java/org/ktb/modie/presentation/v1/dto/GetMeetPaymentResponse.java
+++ b/src/main/java/org/ktb/modie/presentation/v1/dto/GetMeetPaymentResponse.java
@@ -1,0 +1,15 @@
+package org.ktb.modie.presentation.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetMeetPaymentResponse(
+    @Schema(description = "은행 이름", example = "신한은행")
+    String bankName,
+
+    @Schema(description = "계좌 번호", example = "11045678901234")
+    String accountNumber,
+
+    @Schema(description = "모임 인원", example = "3")
+    int memberCount
+) {
+}

--- a/src/main/java/org/ktb/modie/service/MeetService.java
+++ b/src/main/java/org/ktb/modie/service/MeetService.java
@@ -11,6 +11,7 @@ import org.ktb.modie.domain.User;
 import org.ktb.modie.domain.UserMeet;
 import org.ktb.modie.presentation.v1.dto.CreateMeetRequest;
 import org.ktb.modie.presentation.v1.dto.CreateMeetResponse;
+import org.ktb.modie.presentation.v1.dto.GetMeetPaymentResponse;
 import org.ktb.modie.presentation.v1.dto.MeetDto;
 import org.ktb.modie.presentation.v1.dto.MeetListResponse;
 import org.ktb.modie.presentation.v1.dto.MeetSummaryDto;
@@ -381,5 +382,22 @@ public class MeetService {
         }
 
         return "member"; // 탈퇴하지 않은 유저는 멤버
+    }
+
+    public GetMeetPaymentResponse getMeetPaymentInfo(String userId, Long meetId) {
+        Meet meet = meetRepository.findById(meetId)
+            .orElseThrow(() -> new BusinessException(CustomErrorCode.MEETING_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(CustomErrorCode.USER_NOT_FOUND));
+
+        // 요청한 사용자와 방장이 일치하는지
+        if (!meet.getOwner().getUserId().equals(userId)) {
+            throw new BusinessException(CustomErrorCode.PERMISSION_DENIED_NOT_OWNER);
+        }
+
+        int count = userMeetRepository.countByMeetAndDeletedAtIsNull(meet) + 1;
+
+        return new GetMeetPaymentResponse(meet.getOwner().getBankName(), meet.getOwner().getAccountNumber(), count);
     }
 }


### PR DESCRIPTION
### Description
모임 정산 시 방장의 계좌 정보 및 정산 비용 1/N 반환하도록 API 구현

### Related Issues
- Resolves #107 

### Changes Made
1. Response DTO 생성
2. Controller 구현
3. Service 로직 구현

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.